### PR TITLE
[S] DAT-497 support relative path imports

### DIFF
--- a/src/visit.rs
+++ b/src/visit.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::{
     error::Error,
     fs::canonicalize,
-    path::{Path, PathBuf, StripPrefixError},
+    path::{Path, PathBuf},
 };
 
 pub fn visit_path(

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -146,6 +146,14 @@ fn test_normalize_import() {
         ),
         "src/entity/sub-dir/test-file"
     );
+    assert_eq!(
+        normalize_import(
+            "src/entity/sub-dir/test-file",
+            Path::new("/Home/code/lib/system"),
+            Path::new("/Home/code/lib/system/src/entity")
+        ),
+        "src/entity/sub-dir/test-file"
+    );
 }
 
 // Copied from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -133,8 +133,10 @@ fn normalize_relative_import(
         .parent()
         .expect("Expected a parent directory to exist");
     let canonicalized_directory_path = canonicalize(directory_path)?;
-    Ok(canonicalized_directory_path
+    let normalized_import = canonicalized_directory_path
         .join(file_name)
         .strip_prefix(root_directory)?
-        .to_path_buf())
+        .to_path_buf();
+
+    Ok(normalized_import)
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -122,7 +122,7 @@ fn canonicalize_import_path(
     root_directory: &Path,
     current_directory: &Path,
 ) -> Result<PathBuf, Box<dyn Error>> {
-    if import.is_empty() {
+    if import.trim().is_empty() {
         // Edge case handling.
         return Ok(PathBuf::from(import));
     }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -139,6 +139,8 @@ fn canonicalize_import_path(
         fully_qualified_path = root_directory.join(import_path);
     }
 
+    // We expect there to always be a parent directory since we
+    // append the import path to a directory.
     let directory_path = fully_qualified_path
         .parent()
         .expect("Unable to get parent directory");

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -2,7 +2,11 @@ use crate::{
     disallowed, files, rules, ts_reader,
     violations::{DisallowedImportViolation, Violation},
 };
-use std::{error::Error, fs::canonicalize, path::Path};
+use std::{
+    error::Error,
+    fs::canonicalize,
+    path::{Path, PathBuf},
+};
 
 pub fn visit_path(
     violations: &mut Vec<Violation>,
@@ -113,21 +117,22 @@ fn visit_directories(
     Ok(())
 }
 
-fn normalize_import(import: &str, root: &Path, current: &Path) -> String {
+fn normalize_import(import: &str, root: &Path, current: &Path) -> PathBuf {
     if import.starts_with(".") {
         let full_path = current.join(Path::new(&import));
+
         let file_name = full_path.file_name().expect("Unable to get file name");
         let directory_path = full_path.parent().expect("Unable to get parent for path");
+
         let canonicalized_path_directory =
             canonicalize(directory_path).expect("Unable to canonicalize path");
         let canonicalized_path = canonicalized_path_directory.join(file_name);
+
         return canonicalized_path
             .strip_prefix(root)
             .expect("Failed to strip prefix")
-            .to_str()
-            .expect("Failed to convert path to string")
-            .to_string();
+            .to_path_buf();
     }
 
-    return import.to_string();
+    return PathBuf::from(import);
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -118,10 +118,10 @@ fn normalize_import(import: &str, root: &Path, current: &Path) -> String {
         let full_path = current.join(Path::new(&import));
         let file_name = full_path.file_name().expect("Unable to get file name");
         let directory_path = full_path.parent().expect("Unable to get parent for path");
-        let normalized_path_directory =
+        let canonicalized_path_directory =
             canonicalize(directory_path).expect("Unable to canonicalize path");
-        let normalized_path = normalized_path_directory.join(file_name);
-        return normalized_path
+        let canonicalized_path = canonicalized_path_directory.join(file_name);
+        return canonicalized_path
             .strip_prefix(root)
             .expect("Failed to strip prefix")
             .to_str()

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -122,11 +122,16 @@ fn canonicalize_import_path(
     root_directory: &Path,
     current_directory: &Path,
 ) -> Result<PathBuf, Box<dyn Error>> {
+    if import.is_empty() {
+        // Edge case handling.
+        return Ok(PathBuf::from(import));
+    }
+
     let import_path = Path::new(&import);
     let file_name = import_path.file_name().unwrap_or_default();
 
     let fully_qualified_path: PathBuf;
-    if import_path.starts_with(".") {
+    if import.starts_with(".") {
         // Relative imports are relative to the current directory of the file.
         fully_qualified_path = current_directory.join(import_path);
     } else {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -59,9 +59,9 @@ fn check_files_for_disallowed_imports(
 
         let imports = ts_reader::read_ts_imports(&full_path)?;
         for import in imports {
-            let normalized_import = normalize_relative_import(&import, root, current)?;
+            let canonicalized_import_path = canonicalize_import_path(&import, root, current)?;
             for disallowed_import in disallowed_imports {
-                if normalized_import.starts_with(disallowed_import) {
+                if canonicalized_import_path.starts_with(disallowed_import) {
                     let violation = DisallowedImportViolation {
                         file_path: relative_path.to_str().expect("").to_string(),
                         disallowed_import: disallowed_import.clone(),
@@ -117,7 +117,7 @@ fn visit_directories(
     Ok(())
 }
 
-fn normalize_relative_import(
+fn canonicalize_import_path(
     import: &str,
     root_directory: &Path,
     current_directory: &Path,
@@ -144,10 +144,10 @@ fn normalize_relative_import(
         return Ok(import_path.to_path_buf());
     };
 
-    let normalized_import = canonicalized_directory_path
+    let path_from_root = canonicalized_directory_path
         .join(file_name)
         .strip_prefix(root_directory)?
         .to_path_buf();
 
-    Ok(normalized_import)
+    Ok(path_from_root)
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -123,7 +123,9 @@ fn canonicalize_import_path(
     current_directory: &Path,
 ) -> Result<PathBuf, Box<dyn Error>> {
     if import.trim().is_empty() {
-        // Edge case handling.
+        // Edge case handling. An empty string would lead to us
+        // resolving the root directory, and stripping the
+        // root_directory prefix would fail.
         return Ok(PathBuf::from(import));
     }
 

--- a/tests/fixtures/sample.ts
+++ b/tests/fixtures/sample.ts
@@ -2,4 +2,4 @@ import * as foo from "foo";
 // ts_deplint ignore
 import * as bar from "bar/bar";
 import * as baz from "baz/baz/baz";
-import * as baz from "./baz/baz";
+import * as bay from "./baz/bay";

--- a/tests/fixtures/sample.ts
+++ b/tests/fixtures/sample.ts
@@ -1,5 +1,5 @@
-import * as foo from 'foo';
+import * as foo from "foo";
 // ts_deplint ignore
-import * as bar from 'bar/bar';
-import * as baz from 'baz/baz/baz';
-
+import * as bar from "bar/bar";
+import * as baz from "baz/baz/baz";
+import * as baz from "./baz/baz";

--- a/tests/ts_reader_test.rs
+++ b/tests/ts_reader_test.rs
@@ -24,6 +24,6 @@ mod tests {
         assert!(result.is_ok());
 
         let ts_imports = result.unwrap();
-        assert_eq!(ts_imports, vec!["foo", "baz/baz/baz"]);
+        assert_eq!(ts_imports, vec!["foo", "baz/baz/baz", "./baz/baz"]);
     }
 }

--- a/tests/ts_reader_test.rs
+++ b/tests/ts_reader_test.rs
@@ -24,6 +24,6 @@ mod tests {
         assert!(result.is_ok());
 
         let ts_imports = result.unwrap();
-        assert_eq!(ts_imports, vec!["foo", "baz/baz/baz", "./baz/baz"]);
+        assert_eq!(ts_imports, vec!["foo", "baz/baz/baz", "./baz/bay"]);
     }
 }


### PR DESCRIPTION
This enables support for imports from a relative path (`../some/path/to/file`) as opposed to an absolute path (`src/some/path/to/file`)

Test results when i intentionally break the configs to prevent an import 
<img width="802" alt="image" src="https://github.com/user-attachments/assets/f41113c4-5dfe-496a-b167-66587eeea85a" />
